### PR TITLE
第9章1まで。usersテーブルにremember_digestカラムを追加。cookieに署名付きidとremember_token(ハ…

### DIFF
--- a/src/app/controllers/sessions_controller.rb
+++ b/src/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
       log_in user
+      remember user
       redirect_to user
     else
       flash.now[:danger] = 'Invalid email/password combination'
@@ -15,7 +16,8 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     redirect_to root_url
   end
+
 end

--- a/src/app/helpers/sessions_helper.rb
+++ b/src/app/helpers/sessions_helper.rb
@@ -5,9 +5,24 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
-  # 現在ログイン中のユーザーを返す (いる場合)
+  # ユーザーのセッションを永続的にする
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  # 記憶トークンcookieに対応するユーザーを返す
   def current_user
-    @current_user ||= User.find_by(id: session[:user_id])
+    if (user_id = session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.signed[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
+    end
   end
 
   # ユーザーがログインしていればtrue、その他ならfalseを返す
@@ -15,8 +30,16 @@ module SessionsHelper
     !current_user.nil?
   end
 
+  # 永続的セッションを破棄する
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
   # 現在のユーザーをログアウトする
   def log_out
+    forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end

--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  attr_accessor :remember_token
   before_save { email.downcase! }
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
@@ -13,5 +14,27 @@ class User < ApplicationRecord
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
+  end
+
+  # ランダムなトークンを返す
+  def User.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  # 永続セッションのためにユーザーをデータベースに記憶する
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
+  end
+
+  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  def authenticated?(remember_token)
+    return false if remember_digest.nil?
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
+
+  # ユーザーのログイン情報を破棄する
+  def forget
+    update_attribute(:remember_digest, nil)
   end
 end

--- a/src/db/migrate/20211021103134_add_remember_digest_to_users.rb
+++ b/src/db/migrate/20211021103134_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20211019044134) do
+ActiveRecord::Schema.define(version: 20211021103134) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3" do |t|
     t.string   "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20211019044134) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.string   "password_digest"
+    t.string   "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
   end
 

--- a/src/test/integration/users_login_test.rb
+++ b/src/test/integration/users_login_test.rb
@@ -30,6 +30,8 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
       delete logout_path
       assert_not is_logged_in?
       assert_redirected_to root_url
+      # 2番目のウィンドウでログアウトをクリックするユーザーをシミュレートする
+      delete logout_path
       follow_redirect!
       assert_select "a[href=?]", login_path
       assert_select "a[href=?]", logout_path, count: 0

--- a/src/test/models/user_test.rb
+++ b/src/test/models/user_test.rb
@@ -72,5 +72,8 @@ class UserTest < ActiveSupport::TestCase
     @user.password = @user.password_confirmation = "a" * 5
     assert_not @user.valid?
   end
-
+  
+  test "authenticated? should return false for a user with nil digest" do
+      assert_not @user.authenticated?('')
+  end
 end


### PR DESCRIPTION
…ッシュ化される前のremember_digest)を入れて管理。cookieとdbのやりとりをするために[userモデル、sessionコントローラー、sessionヘルパー、統合テストのusers_login_test]を修正